### PR TITLE
deal with more corner cases

### DIFF
--- a/scripts/fix-engine-names.py
+++ b/scripts/fix-engine-names.py
@@ -107,6 +107,7 @@ def amendEngineNames(player):
     name = name.replace("Cheng4", "Cheng 4")
     name = name.replace("Chess22k", "chess22k")
     name = re.sub(r"[lL]c0", "LCZero", name)
+    name = name.replace("pirarucu", "Pirarucu")
     # replace underscore with digital point
     name = name.replace("0_1pct", "0.1pct")
     # include an underscore before 0.1pct, 10pct, 30pct etc
@@ -171,6 +172,7 @@ def fixVariousVersions(t):
             "LCZero",
             "LCZeroCPU_3pct",
             "Rodent",
+            "Rybka",
             "Sjeng",
             "SlowChess_Blitz",
             "Stoofvlees",

--- a/scripts/fix-engine-names.py
+++ b/scripts/fix-engine-names.py
@@ -108,7 +108,7 @@ def amendEngineNames(player):
     name = name.replace("Chess22k", "chess22k")
     name = re.sub(r"[lL]c0", "LCZero", name)
     name = name.replace("pirarucu", "Pirarucu")
-    # replace underscore with digital point
+    # replace underscore with decimal point
     name = name.replace("0_1pct", "0.1pct")
     # include an underscore before 0.1pct, 10pct, 30pct etc
     name = re.sub(r"([a-zA-Z])(\d+(\.\d+)?pct)", r"\1_\2", name)

--- a/scripts/fix-engine-names.py
+++ b/scripts/fix-engine-names.py
@@ -178,7 +178,7 @@ def fixVariousVersions(t):
             "Zappa",
         ]:
             name = n
-            version = v + " " + version
+            version = v + " " + version if version else v
             version = version.replace(" ", "_")
     name = name.replace("SlowChess_Blitz", "SlowChess Blitz")
     return name, version, tag

--- a/scripts/fix-engine-names.py
+++ b/scripts/fix-engine-names.py
@@ -86,6 +86,8 @@ def addFixedStockfish15():
 
 def amendEngineNames(player):
     name, space, rest = player.partition(" ")
+    # "Cheng 4 0.36c" will then be dealt with in fixVariousVersions() below
+    name = name.replace("Cheng4", "Cheng 4")
     name = name.replace("Chess22k", "chess22k")
     name = re.sub(r"[lL]c0", "LCZero", name)
     # replace underscore with digital point
@@ -93,9 +95,9 @@ def amendEngineNames(player):
     # include an underscore before 0.1pct, 10pct, 30pct etc
     name = re.sub(r"([a-zA-Z])(\d+(\.\d+)?pct)", r"\1_\2", name)
     # rename kn to k
-    name = re.sub(r"([0-9])(kn)", r"\1k", name)
+    name = re.sub(r"([0-9])kn", r"\1k", name)
     # rename Mn to M
-    name = re.sub(r"([0-9])(Mn)", r"\1M", name)
+    name = re.sub(r"([0-9])Mn", r"\1M", name)
     # include an underscore before 1n, 100k, 10M, 1G etc
     if name not in ["chess22k", "we4k"]:
         name = re.sub(r"([a-zA-Z])(\d+(\d+)?[nkMG])", r"\1_\2", name)
@@ -135,6 +137,33 @@ def fixVariousTags(t):
     return name, version, tag
 
 
+def fixVariousVersions(t):
+    name, version, tag = t
+    if " " in name:
+        n, _, v = name.partition(" ")
+        if n in [
+            "Antifish",
+            "Cheng",
+            "Cheese",
+            "DeepSjeng",
+            "Fritz",
+            "Glaurung",
+            "Igel",
+            "Laser",
+            "LCZero",
+            "LCZeroCPU_3pct",
+            "Rodent",
+            "Sjeng",
+            "Stoofvlees",
+            "Wasp",
+            "Zappa",
+        ]:
+            name = n
+            version = v + " " + version
+            version = version.replace(" ", "_")
+    return name, version, tag
+
+
 def serializeNameVersionTriplet(t):
     s1 = "" if t[1] == "" else f" ({t[1]})"
     s2 = "" if t[2] == "" else f" [{t[2]}]"
@@ -168,6 +197,7 @@ def fixEngineNames():
             nameVersionTriplet = fixCopyTags(nameVersionTriplet)
             nameVersionTriplet = fixMemoryAndThreadTags(nameVersionTriplet)
             nameVersionTriplet = fixVariousTags(nameVersionTriplet)
+            nameVersionTriplet = fixVariousVersions(nameVersionTriplet)
 
             print(
                 f'[{playerTagMatch.group(1)} "{serializeNameVersionTriplet(nameVersionTriplet)}"]'

--- a/scripts/fix-engine-names.py
+++ b/scripts/fix-engine-names.py
@@ -22,6 +22,21 @@ exceptionalNames = {
     "Stockfish_13_CCRL 64-bit_4CPU": ("Stockfish", "13", "CCRL 64-bit 4CPU"),
     "Stockfish_15_CCRL 64-bit_4CPU": ("Stockfish", "15", "CCRL 64-bit 4CPU"),
     "Chat": ("TCEC Chat", "", ""),
+    "EtherealClassical 12.89": ("Ethereal", "12.89_Classical", ""),
+    "SFNNUE 20200704-StockFiNN-0.2": ("Stockfish", "20200704-StockFiNN-0.2", "SFNNUE"),
+    "StockfishNNUE 20200704-StockFiNN-0.2": (
+        "Stockfish",
+        "20200704-StockFiNN-0.2",
+        "StockfishNNUE",
+    ),
+    "SimpleEval2 20200731r14": ("SimpleEval", "20200731r14", "2"),
+    "Bluefish Dev": ("Stockfish", "Dev", "Bluefish"),
+    "Booot2 6.5": ("Booot", "6.5", "2"),
+    "RubiChessClassical 2.0.1": ("RubiChess", "2.0.1_Classical", ""),
+    "StockfishClassical": ("Stockfish", "Classical", ""),
+    "StockfishClassical 202007311012": ("Stockfish", "202007311012_Classical", ""),
+    "Redfish 19070105": ("Stockfish", "19070105", "Redfish"),
+    "Redfish 20191209": ("Stockfish", "20191209", "Redfish"),
 }
 
 
@@ -85,8 +100,10 @@ def addFixedStockfish15():
 
 
 def amendEngineNames(player):
+    # "SlowChess_Blitz 2.41 avx" will be dealt with in fixVariousVersions()
+    player = player.replace("SlowChess Blitz", "SlowChess_Blitz")
     name, space, rest = player.partition(" ")
-    # "Cheng 4 0.36c" will then be dealt with in fixVariousVersions() below
+    # "Cheng 4 0.36c" will then be dealt with in fixVariousVersions()
     name = name.replace("Cheng4", "Cheng 4")
     name = name.replace("Chess22k", "chess22k")
     name = re.sub(r"[lL]c0", "LCZero", name)
@@ -123,7 +140,7 @@ def fixCopyTags(t):
 
 def fixMemoryAndThreadTags(t):
     name, version, tag = t
-    if version in ["64GiB", "128GiB", "256GiB", "256th"]:
+    if version in ["16GiB", "64GiB", "128GiB", "256GiB", "256th"]:
         tag = version
         name, _, version = name.rpartition(" ")
     return name, version, tag
@@ -146,6 +163,7 @@ def fixVariousVersions(t):
             "Cheng",
             "Cheese",
             "DeepSjeng",
+            "Ethereal",
             "Fritz",
             "Glaurung",
             "Igel",
@@ -154,6 +172,7 @@ def fixVariousVersions(t):
             "LCZeroCPU_3pct",
             "Rodent",
             "Sjeng",
+            "SlowChess_Blitz",
             "Stoofvlees",
             "Wasp",
             "Zappa",
@@ -161,6 +180,7 @@ def fixVariousVersions(t):
             name = n
             version = v + " " + version
             version = version.replace(" ", "_")
+    name = name.replace("SlowChess_Blitz", "SlowChess Blitz")
     return name, version, tag
 
 

--- a/scripts/fix-engine-names.py
+++ b/scripts/fix-engine-names.py
@@ -9,45 +9,53 @@ import sys
 # additional information.
 exceptionalNames = {
     # format: <player tag> : (<engine name>, <engine version>, <optional special tag>)
-    'Koivisto2 4.41' : ('Koivisto', '4.41', '2'),
-    'MrBob 1.0.0_dev' : ('Mr_Bob', '1.0.0_dev'),
-    'Stockfish0_1pct 20191225' : ('Stockfish0.1pct', '20191225'),
-    'Weiss 0.10-dev-20200525 1' : ('Weiss', '0.10-dev-20200525' ,'1'),
-    'Weiss 0.10-dev-20200525 2' : ('Weiss', '0.10-dev-20200525' ,'2'),
+    "Koivisto2 4.41": ("Koivisto", "4.41", "2"),
+    "MrBob 1.0.0_dev": ("Mr_Bob", "1.0.0_dev", ""),
+    "Weiss 0.10-dev-20200525 1": ("Weiss", "0.10-dev-20200525", "1"),
+    "Weiss 0.10-dev-20200525 2": ("Weiss", "0.10-dev-20200525", "2"),
+    "Crafty_25.2_CCRL 64-bit 4CPU": ("Crafty", "25.2", "CCRL 64-bit 4CPU"),
+    "Glaurung_2.2_CCRL 64-bit_4CPU": ("Glaurung", "2.2", "CCRL 64-bit 4CPU"),
+    "Gull_20170410_CCRL 64-bit 4CPU": ("Gull", "20170410", "CCRL 64-bit 4CPU"),
+    "Komodo_10_CCRL 64-bit_4CPU": ("Komodo", "10", "CCRL 64-bit 4CPU"),
+    "Komodo_14_CCRL 64-bit_4CPU": ("Komodo", "14", "CCRL 64-bit 4CPU"),
+    "Stockfish_11_CCRL 64-bit_4CPU": ("Stockfish", "11", "CCRL 64-bit 4CPU"),
+    "Stockfish_13_CCRL 64-bit_4CPU": ("Stockfish", "13", "CCRL 64-bit 4CPU"),
+    "Stockfish_15_CCRL 64-bit_4CPU": ("Stockfish", "15", "CCRL 64-bit 4CPU"),
+    "Chat": ("TCEC Chat", "", ""),
+}
 
-    'Crafty_25.2_CCRL 64-bit 4CPU' : ('Crafty', '25.2', 'CCRL 64-bit 4CPU'),
-    'Glaurung_2.2_CCRL 64-bit_4CPU' : ('Glaurung', '2.2', 'CCRL 64-bit 4CPU'),
-    'Gull_20170410_CCRL 64-bit 4CPU' : ('Gull', '20170410', 'CCRL 64-bit 4CPU'),
-    'Komodo_10_CCRL 64-bit_4CPU' : ('Komodo', '10', 'CCRL 64-bit 4CPU'),
-    'Komodo_14_CCRL 64-bit_4CPU' : ('Komodo', '14', 'CCRL 64-bit 4CPU'),
-    'Stockfish_11_CCRL 64-bit_4CPU' : ('Stockfish', '11', 'CCRL 64-bit 4CPU'),
-    'Stockfish_13_CCRL 64-bit_4CPU' : ('Stockfish', '13', 'CCRL 64-bit 4CPU'),
-    'Stockfish_15_CCRL 64-bit_4CPU' : ('Stockfish', '15', 'CCRL 64-bit 4CPU'),
-
-    }
 
 def addSwissTestStockfishVersions():
     for i in range(1, 43):
-        exceptionalNames[f"{i:02}Stockfish 2021013116"] = ('Stockfish', '2021013116', f"{i:02}")
-        exceptionalNames[f"{i:02}StockfishClassical 202007311012"] = ('StockfishClassical', '202007311012', f"{i:02}")
+        exceptionalNames[f"{i:02}Stockfish 2021013116"] = (
+            "Stockfish",
+            "2021013116",
+            f"{i:02}",
+        )
+        exceptionalNames[f"{i:02}StockfishClassical 202007311012"] = (
+            "Stockfish",
+            "202007311012_Classical",
+            f"{i:02}",
+        )
+
 
 def addSufiTaggedEngines():
     sufiTriplets = [
-        ('Houdini', '1.5a', 'Sufi 1&2'),
-        ('Houdini', '3', 'Sufi 4'),
-        ('Houdini', '6.03', 'Sufi 10'),
-        ('Komodo', '8', 'Sufi 5'),
-        ('Komodo', '9.2', 'Sufi 7'),
-        ('Komodo', '9.3', 'Sufi 8'),
-        ('LCZero', 'v0.21.1-nT40.T8.610', 'Sufi 15'),
-        ('Rybka', '4.1', 'Sufi 3'),
-        ('Stockfish', '180614', 'Sufi 12'),
-        ('Stockfish', '18102108', 'Sufi 13'),
-        ('Stockfish', '190203', 'Sufi 14'),
-        ('Stockfish', '260318', 'Sufi 11'),
-        ('Stockfish', '6', 'Sufi 6'),
-        ('Stockfish', '8', 'Sufi 9'),
-        ]
+        ("Houdini", "1.5a", "Sufi 1&2"),
+        ("Houdini", "3", "Sufi 4"),
+        ("Houdini", "6.03", "Sufi 10"),
+        ("Komodo", "8", "Sufi 5"),
+        ("Komodo", "9.2", "Sufi 7"),
+        ("Komodo", "9.3", "Sufi 8"),
+        ("LCZero", "v0.21.1-nT40.T8.610", "Sufi 15"),
+        ("Rybka", "4.1", "Sufi 3"),
+        ("Stockfish", "180614", "Sufi 12"),
+        ("Stockfish", "18102108", "Sufi 13"),
+        ("Stockfish", "190203", "Sufi 14"),
+        ("Stockfish", "260318", "Sufi 11"),
+        ("Stockfish", "6", "Sufi 6"),
+        ("Stockfish", "8", "Sufi 9"),
+    ]
 
     for i in sufiTriplets:
         name1 = f"{i[0]} {i[1]} {i[2]}"
@@ -55,42 +63,115 @@ def addSufiTaggedEngines():
         exceptionalNames[name1] = i
         exceptionalNames[name2] = i
 
+
+def addFixedStockfish15():
+    # change "Stockfish_15_100M" to "Stockfish_100M (15)" etc.
+    for i in [1, 3, 10, 30, 100, 300]:
+        for s in ["k", "M", "G"]:
+            suffix = f"{i}{s}"
+            name = "Stockfish_15_" + suffix
+            newname = "Stockfish_" + suffix
+            exceptionalNames[name] = (newname, "15", "")
+    exceptionalNames["Stockfish_15_300M scaled_to_450Mnodes"] = (
+        "Stockfish_300M",
+        "15",
+        "scaled to 450Mnodes",
+    )
+    exceptionalNames["Renamedfish_15_3M"] = (
+        "Stockfish_3M",
+        "15",
+        "renamed",  # or "copy"
+    )
+
+
+def amendEngineNames(player):
+    name, space, rest = player.partition(" ")
+    name = name.replace("Chess22k", "chess22k")
+    name = re.sub(r"[lL]c0", "LCZero", name)
+    # replace underscore with digital point
+    name = name.replace("0_1pct", "0.1pct")
+    # include an underscore before 0.1pct, 10pct, 30pct etc
+    name = re.sub(r"([a-zA-Z])(\d+(\.\d+)?pct)", r"\1_\2", name)
+    # rename kn to k
+    name = re.sub(r"([0-9])(kn)", r"\1k", name)
+    # rename Mn to M
+    name = re.sub(r"([0-9])(Mn)", r"\1M", name)
+    # include an underscore before 1n, 100k, 10M, 1G etc
+    if name not in ["chess22k", "we4k"]:
+        name = re.sub(r"([a-zA-Z])(\d+(\d+)?[nkMG])", r"\1_\2", name)
+    name = name.replace("Stockfishd1", "Stockfish_d1")
+    name = name.replace("StockfishDepth", "Stockfish_d")
+    name = name.replace("Stockfish1thread", "Stockfish_1thread")
+    return name + space + rest
+
+
+def fixCopyTags(t):
+    name, version, tag = t
+    if name.endswith(" copy"):
+        name, c, _ = name.rpartition(" copy")
+        tag = "copy" if tag == "" else tag + "_copy"
+    if version.endswith("_copy"):
+        version, c, _ = version.rpartition("_copy")
+        tag = "copy" if tag == "" else tag + "_copy"
+    if version == "copy":
+        version = ""
+        tag = "copy" if tag == "" else tag + "_copy"
+    return name, version, tag
+
+
+def fixMemoryAndThreadTags(t):
+    name, version, tag = t
+    if version in ["64GiB", "128GiB", "256GiB", "256th"]:
+        tag = version
+        name, _, version = name.rpartition(" ")
+    return name, version, tag
+
+
+def fixVariousTags(t):
+    name, version, tag = t
+    if version in ["interleave", "localalloc", "none"]:
+        tag = version
+        name, _, version = name.rpartition(" ")
+    return name, version, tag
+
+
 def serializeNameVersionTriplet(t):
-    if len(t) == 1:
-        return t[0]
-    elif len(t) == 2:
-        return f"{t[0]} ({t[1]})"
-    else:
-        return f"{t[0]} ({t[1]}) [{t[2]}]"
+    s1 = "" if t[1] == "" else f" ({t[1]})"
+    s2 = "" if t[2] == "" else f" [{t[2]}]"
+    return f"{t[0]}{s1}{s2}"
+
 
 def fixEngineNames():
+    playerTagMatcher = re.compile(r'\[(White|Black) "([^"]*)"\]', re.ASCII)
 
-    playerTagMatcher = re.compile(
-        r'\[(White|Black) "([^"]*)"\]',
-        re.ASCII)
-
-    regularNameVersionMatcher = re.compile(
-        r'(.*) ([^ ]+)',
-        re.ASCII)
+    regularNameVersionMatcher = re.compile(r"(.*) ([^ ]+)", re.ASCII)
 
     for line in sys.stdin:
-        line = line.rstrip() # let's skip the newline
+        line = line.rstrip()  # let's skip the newline
 
         playerTagMatch = playerTagMatcher.fullmatch(line)
         if playerTagMatch:
             player = playerTagMatch.group(2)
+
+            player = amendEngineNames(player)
 
             if player in exceptionalNames:
                 nameVersionTriplet = exceptionalNames[player]
 
             elif regularNameVersionMatcher.fullmatch(player):
                 m = regularNameVersionMatcher.fullmatch(player)
-                nameVersionTriplet = ( m.group(1), m.group(2) )
+                nameVersionTriplet = (m.group(1), m.group(2), "")
 
             else:
-                nameVersionTriplet = ( player, )
+                nameVersionTriplet = (player, "", "")
 
-            print(f"[{playerTagMatch.group(1)} \"{serializeNameVersionTriplet(nameVersionTriplet)}\"]")
+            nameVersionTriplet = fixCopyTags(nameVersionTriplet)
+            nameVersionTriplet = fixMemoryAndThreadTags(nameVersionTriplet)
+            nameVersionTriplet = fixVariousTags(nameVersionTriplet)
+
+            print(
+                f'[{playerTagMatch.group(1)} "{serializeNameVersionTriplet(nameVersionTriplet)}"]'
+            )
 
         else:
             print(line)
@@ -99,12 +180,16 @@ def fixEngineNames():
 def main(argv):
     # version check -- this script was developed with Python 3.9
     if sys.version_info < (3, 9):
-        warning(f"Python version {sys.version_info.major}.{sys.version_info.minor} is not at least 3.9!")
+        warning(
+            f"Python version {sys.version_info.major}.{sys.version_info.minor} is not at least 3.9!"
+        )
 
     addSwissTestStockfishVersions()
     addSufiTaggedEngines()
+    addFixedStockfish15()
 
     fixEngineNames()
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/scripts/fix-engine-names.py
+++ b/scripts/fix-engine-names.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+import re
+import sys
+
+# Exceptional names. Individually mapped to name / version / optional special tag
+#
+# Special tag is rarely used. Usually, it is for event-specific
+# additional information.
+exceptionalNames = {
+    # format: <player tag> : (<engine name>, <engine version>, <optional special tag>)
+    'Koivisto2 4.41' : ('Koivisto', '4.41', '2'),
+    'MrBob 1.0.0_dev' : ('Mr_Bob', '1.0.0_dev'),
+    'Stockfish0_1pct 20191225' : ('Stockfish0.1pct', '20191225'),
+    'Weiss 0.10-dev-20200525 1' : ('Weiss', '0.10-dev-20200525' ,'1'),
+    'Weiss 0.10-dev-20200525 2' : ('Weiss', '0.10-dev-20200525' ,'2'),
+
+    'Crafty_25.2_CCRL 64-bit 4CPU' : ('Crafty', '25.2', 'CCRL 64-bit 4CPU'),
+    'Glaurung_2.2_CCRL 64-bit_4CPU' : ('Glaurung', '2.2', 'CCRL 64-bit 4CPU'),
+    'Gull_20170410_CCRL 64-bit 4CPU' : ('Gull', '20170410', 'CCRL 64-bit 4CPU'),
+    'Komodo_10_CCRL 64-bit_4CPU' : ('Komodo', '10', 'CCRL 64-bit 4CPU'),
+    'Komodo_14_CCRL 64-bit_4CPU' : ('Komodo', '14', 'CCRL 64-bit 4CPU'),
+    'Stockfish_11_CCRL 64-bit_4CPU' : ('Stockfish', '11', 'CCRL 64-bit 4CPU'),
+    'Stockfish_13_CCRL 64-bit_4CPU' : ('Stockfish', '13', 'CCRL 64-bit 4CPU'),
+    'Stockfish_15_CCRL 64-bit_4CPU' : ('Stockfish', '15', 'CCRL 64-bit 4CPU'),
+
+    }
+
+def addSwissTestStockfishVersions():
+    for i in range(1, 43):
+        exceptionalNames[f"{i:02}Stockfish 2021013116"] = ('Stockfish', '2021013116', f"{i:02}")
+        exceptionalNames[f"{i:02}StockfishClassical 202007311012"] = ('StockfishClassical', '202007311012', f"{i:02}")
+
+def addSufiTaggedEngines():
+    sufiTriplets = [
+        ('Houdini', '1.5a', 'Sufi 1&2'),
+        ('Houdini', '3', 'Sufi 4'),
+        ('Houdini', '6.03', 'Sufi 10'),
+        ('Komodo', '8', 'Sufi 5'),
+        ('Komodo', '9.2', 'Sufi 7'),
+        ('Komodo', '9.3', 'Sufi 8'),
+        ('LCZero', 'v0.21.1-nT40.T8.610', 'Sufi 15'),
+        ('Rybka', '4.1', 'Sufi 3'),
+        ('Stockfish', '180614', 'Sufi 12'),
+        ('Stockfish', '18102108', 'Sufi 13'),
+        ('Stockfish', '190203', 'Sufi 14'),
+        ('Stockfish', '260318', 'Sufi 11'),
+        ('Stockfish', '6', 'Sufi 6'),
+        ('Stockfish', '8', 'Sufi 9'),
+        ]
+
+    for i in sufiTriplets:
+        name1 = f"{i[0]} {i[1]} {i[2]}"
+        name2 = f"{i[2].replace(' ', '')} {i[0]} {i[1]}"
+        exceptionalNames[name1] = i
+        exceptionalNames[name2] = i
+
+def serializeNameVersionTriplet(t):
+    if len(t) == 1:
+        return t[0]
+    elif len(t) == 2:
+        return f"{t[0]} ({t[1]})"
+    else:
+        return f"{t[0]} ({t[1]}) [{t[2]}]"
+
+def fixEngineNames():
+
+    playerTagMatcher = re.compile(
+        r'\[(White|Black) "([^"]*)"\]',
+        re.ASCII)
+
+    regularNameVersionMatcher = re.compile(
+        r'(.*) ([^ ]+)',
+        re.ASCII)
+
+    for line in sys.stdin:
+        line = line.rstrip() # let's skip the newline
+
+        playerTagMatch = playerTagMatcher.fullmatch(line)
+        if playerTagMatch:
+            player = playerTagMatch.group(2)
+
+            if player in exceptionalNames:
+                nameVersionTriplet = exceptionalNames[player]
+
+            elif regularNameVersionMatcher.fullmatch(player):
+                m = regularNameVersionMatcher.fullmatch(player)
+                nameVersionTriplet = ( m.group(1), m.group(2) )
+
+            else:
+                nameVersionTriplet = ( player, )
+
+            print(f"[{playerTagMatch.group(1)} \"{serializeNameVersionTriplet(nameVersionTriplet)}\"]")
+
+        else:
+            print(line)
+
+
+def main(argv):
+    # version check -- this script was developed with Python 3.9
+    if sys.version_info < (3, 9):
+        warning(f"Python version {sys.version_info.major}.{sys.version_info.minor} is not at least 3.9!")
+
+    addSwissTestStockfishVersions()
+    addSufiTaggedEngines()
+
+    fixEngineNames()
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
I applied `black` to the script file and changed the triplet to always contain three strings: if they are empty, the output is produced by `serializeNameVersionTriplet` appropriately.

This PR include most of the more automatic changes, in a follow-up I can deal with the remaining manual ones.

The difference in output for `cat TCEC-everything-bonus-test.pgn TCEC-compet.pgn | scripts/fix-engine-names.py | egrep '[[](White|Black) ' | sed -r -e 's/^.{8}//' -e 's/..$//' | sort -u` between your base branch and patch is as follows:
```diff
248d247
< Chat
266c265
< Chess22k (1.10)
---
> chess22k (1.10)
699,700c698,699
< Igel 3.0.5 (128GiB)
< Igel 3.0.5 (256GiB)
---
> Igel (3.0.5) [128GiB]
> Igel (3.0.5) [256GiB]
841c840
< KomodoDragon (2885.00_copy)
---
> KomodoDragon (2885.00) [copy]
850c849
< KomodoDragon (3.1_copy)
---
> KomodoDragon (3.1) [copy]
878c877
< Laser 1.8 beta (256th)
---
> Laser 1.8 (beta) [256th]
885,886d883
< lc0 (16.10520)
< Lc0 (18.11248)
889a887
> LCZero (0.27.0d+Tilps/dje-magic_JH.94-100) [copy]
916c914
< LCZero (0.30-dag-bord-lf-se-2_784058_copy)
---
> LCZero (0.30-dag-bord-lf-se-2_784058) [copy]
921c919
< LCZero (0.30-dag-pr1821_BT2-3250000_copy)
---
> LCZero (0.30-dag-pr1821_BT2-3250000) [copy]
940c938
< LCZero (0.31-dag-e429eeb-BT3-2790000_copy)
---
> LCZero (0.31-dag-e429eeb-BT3-2790000) [copy]
943,948c941,946
< LCZero100n (0.27.0-pr1540ish_JH.94-100)
< LCZero10kn (0.27.0-pr1540ish_JH.94-100)
< LCZero10n (0.27.0-pr1540ish_JH.94-100)
< LCZero10pct (v0.21.1-nT40.T8.610)
< LCZero10pct (v0.21.2-n42547)
< LCZero10pct (v0.25.1-sv-t60-3010)
---
> LCZero_100n (0.27.0-pr1540ish_JH.94-100)
> LCZero_10k (0.27.0-pr1540ish_JH.94-100)
> LCZero_10n (0.27.0-pr1540ish_JH.94-100)
> LCZero_10pct (v0.21.1-nT40.T8.610)
> LCZero_10pct (v0.21.2-n42547)
> LCZero_10pct (v0.25.1-sv-t60-3010)
950,957c948,956
< LCZero1kn (0.27.0-pr1540ish_JH.94-100)
< LCZero1kn (v0.21.2-n42547)
< LCZero1n (0.27.0-pr1540ish_JH.94-100)
< LCZero1pct (v0.21.2-n42547)
< LCZero30pct (0.29-dev+_AP-Mish-2M)
< LCZero30pct (v0.22.0-nT40B.4-160)
< LCZero3pct (v0.21.2-n42547)
< LCZero copy (0.27.0d+Tilps/dje-magic_JH.94-100)
---
> LCZero (16.10520)
> LCZero (18.11248)
> LCZero_1k (0.27.0-pr1540ish_JH.94-100)
> LCZero_1k (v0.21.2-n42547)
> LCZero_1n (0.27.0-pr1540ish_JH.94-100)
> LCZero_1pct (v0.21.2-n42547)
> LCZero_30pct (0.29-dev+_AP-Mish-2M)
> LCZero_30pct (v0.22.0-nT40B.4-160)
> LCZero_3pct (v0.21.2-n42547)
959,961c958,960
< LCZeroCPU10pct (v0.25-n591215)
< LCZeroCPU3pct (v0.25-n591215)
< LCZeroCPU3pct v0.25-n591215 (blitz)
---
> LCZeroCPU_10pct (v0.25-n591215)
> LCZeroCPU_3pct (v0.25-n591215)
> LCZeroCPU_3pct v0.25-n591215 (blitz)
1024c1023
< Marvin 3.4.0 (256th)
---
> Marvin (3.4.0) [256th]
1073,1074c1072,1073
< Minic 3.07 (128GiB)
< Minic 3.07 (64GiB)
---
> Minic (3.07) [128GiB]
> Minic (3.07) [64GiB]
1235d1233
< Renamedfish_15_3M
1304c1302
< rofChade30pct (2.323)
---
> rofChade_30pct (2.323)
1352c1350
< RubiChess 2.2-dev (128GiB)
---
> RubiChess (2.2-dev) [128GiB]
1395c1393
< ScorpioNN (3.0.15.3_copy)
---
> ScorpioNN (3.0.15.3) [copy]
1397c1395
< ScorpioNN (3.0.15.5_copy)
---
> ScorpioNN (3.0.15.5) [copy]
1504c1502
< Stockfish0.1pct (20191225)
---
> Stockfish_0.1pct (20191225)
1508c1506
< Stockfish0.3pct (20191225)
---
> Stockfish_0.3pct (20191225)
1518,1522c1516,1524
< Stockfish100kn (202104151245)
< Stockfish10kn (202104151245)
< Stockfish10Mn (202104151245)
< Stockfish10pct (19050918)
< Stockfish10pct (202003092246)
---
> Stockfish_100k (15)
> Stockfish_100k (202104151245)
> Stockfish_100M (15)
> Stockfish_10k (15)
> Stockfish_10k (202104151245)
> Stockfish_10M (15)
> Stockfish_10M (202104151245)
> Stockfish_10pct (19050918)
> Stockfish_10pct (202003092246)
1535,1536d1536
< Stockfish_15_100k
< Stockfish_15_100M
1538,1542d1537
< Stockfish_15_10k
< Stockfish_15_10M
< Stockfish_15_1G
< Stockfish_15_1k
< Stockfish_15_1M
1544,1550d1538
< Stockfish_15_300k
< Stockfish_15_300M
< Stockfish_15_300M (scaled_to_450Mnodes)
< Stockfish_15_30k
< Stockfish_15_30M
< Stockfish_15_3k
< Stockfish_15_3M
1585,1589c1573,1580
< Stockfish1kn (202104151245)
< Stockfish1Mn (202104151245)
< Stockfish1pct (20200112)
< Stockfish1pct (2020011312)
< Stockfish1thread (202003092246)
---
> Stockfish_1G (15)
> Stockfish_1k (15)
> Stockfish_1k (202104151245)
> Stockfish_1M (15)
> Stockfish_1M (202104151245)
> Stockfish_1pct (20200112)
> Stockfish_1pct (2020011312)
> Stockfish_1thread (202003092246)
1606a1598,1639
> Stockfish (202007311012_Classical) [01]
> Stockfish (202007311012_Classical) [02]
> Stockfish (202007311012_Classical) [03]
> Stockfish (202007311012_Classical) [04]
> Stockfish (202007311012_Classical) [05]
> Stockfish (202007311012_Classical) [06]
> Stockfish (202007311012_Classical) [07]
> Stockfish (202007311012_Classical) [08]
> Stockfish (202007311012_Classical) [09]
> Stockfish (202007311012_Classical) [10]
> Stockfish (202007311012_Classical) [11]
> Stockfish (202007311012_Classical) [12]
> Stockfish (202007311012_Classical) [13]
> Stockfish (202007311012_Classical) [14]
> Stockfish (202007311012_Classical) [15]
> Stockfish (202007311012_Classical) [16]
> Stockfish (202007311012_Classical) [17]
> Stockfish (202007311012_Classical) [18]
> Stockfish (202007311012_Classical) [19]
> Stockfish (202007311012_Classical) [20]
> Stockfish (202007311012_Classical) [21]
> Stockfish (202007311012_Classical) [22]
> Stockfish (202007311012_Classical) [23]
> Stockfish (202007311012_Classical) [24]
> Stockfish (202007311012_Classical) [25]
> Stockfish (202007311012_Classical) [26]
> Stockfish (202007311012_Classical) [27]
> Stockfish (202007311012_Classical) [28]
> Stockfish (202007311012_Classical) [29]
> Stockfish (202007311012_Classical) [30]
> Stockfish (202007311012_Classical) [31]
> Stockfish (202007311012_Classical) [32]
> Stockfish (202007311012_Classical) [33]
> Stockfish (202007311012_Classical) [34]
> Stockfish (202007311012_Classical) [35]
> Stockfish (202007311012_Classical) [36]
> Stockfish (202007311012_Classical) [37]
> Stockfish (202007311012_Classical) [38]
> Stockfish (202007311012_Classical) [39]
> Stockfish (202007311012_Classical) [40]
> Stockfish (202007311012_Classical) [41]
> Stockfish (202007311012_Classical) [42]
1615a1649
> Stockfish (20210113) [copy]
1671c1705
< Stockfish25pct (dev16_202204220817)
---
> Stockfish_25pct (dev16_202204220817)
1677a1712,1714
> Stockfish_300k (15)
> Stockfish_300M (15)
> Stockfish_300M (15) [scaled to 450Mnodes]
1679c1716,1721
< Stockfish3pct (202001231912)
---
> Stockfish_30k (15)
> Stockfish_30M (15)
> Stockfish_3k (15)
> Stockfish_3M (15)
> Stockfish_3M (15) [renamed]
> Stockfish_3pct (202001231912)
1686,1733c1728,1732
< StockfishClassical (202007311012) [01]
< StockfishClassical (202007311012) [02]
< StockfishClassical (202007311012) [03]
< StockfishClassical (202007311012) [04]
< StockfishClassical (202007311012) [05]
< StockfishClassical (202007311012) [06]
< StockfishClassical (202007311012) [07]
< StockfishClassical (202007311012) [08]
< StockfishClassical (202007311012) [09]
< StockfishClassical (202007311012) [10]
< StockfishClassical (202007311012) [11]
< StockfishClassical (202007311012) [12]
< StockfishClassical (202007311012) [13]
< StockfishClassical (202007311012) [14]
< StockfishClassical (202007311012) [15]
< StockfishClassical (202007311012) [16]
< StockfishClassical (202007311012) [17]
< StockfishClassical (202007311012) [18]
< StockfishClassical (202007311012) [19]
< StockfishClassical (202007311012) [20]
< StockfishClassical (202007311012) [21]
< StockfishClassical (202007311012) [22]
< StockfishClassical (202007311012) [23]
< StockfishClassical (202007311012) [24]
< StockfishClassical (202007311012) [25]
< StockfishClassical (202007311012) [26]
< StockfishClassical (202007311012) [27]
< StockfishClassical (202007311012) [28]
< StockfishClassical (202007311012) [29]
< StockfishClassical (202007311012) [30]
< StockfishClassical (202007311012) [31]
< StockfishClassical (202007311012) [32]
< StockfishClassical (202007311012) [33]
< StockfishClassical (202007311012) [34]
< StockfishClassical (202007311012) [35]
< StockfishClassical (202007311012) [36]
< StockfishClassical (202007311012) [37]
< StockfishClassical (202007311012) [38]
< StockfishClassical (202007311012) [39]
< StockfishClassical (202007311012) [40]
< StockfishClassical (202007311012) [41]
< StockfishClassical (202007311012) [42]
< Stockfish copy (20210113)
< Stockfishd1 (202104151245)
< StockfishDepth1 (202007172028)
< StockfishDepth2 (202007172028)
< StockfishDepth3 (202007172028)
< StockfishDepth4 (202007172028)
---
> Stockfish_d1 (202007172028)
> Stockfish_d1 (202104151245)
> Stockfish_d2 (202007172028)
> Stockfish_d3 (202007172028)
> Stockfish_d4 (202007172028)
1750c1749
< Stockfish (dev16_202208061357_copy)
---
> Stockfish (dev16_202208061357) [copy]
1774c1773
< Stockfish (dev-20231105-442c294a_copy)
---
> Stockfish (dev-20231105-442c294a) [copy]
1787,1789c1786,1788
< Stockfish dev-20240605-5688b188 (interleave)
< Stockfish dev-20240605-5688b188 (localalloc)
< Stockfish dev-20240605-5688b188 (none)
---
> Stockfish (dev-20240605-5688b188) [interleave]
> Stockfish (dev-20240605-5688b188) [localalloc]
> Stockfish (dev-20240605-5688b188) [none]
1838a1838
> TCEC Chat
1979c1979
< Wasp 4.10 (copy)
---
> Wasp 4.10 [copy]
2030,2034c2030,2034
< Weiss30pct (1.0-dev)
< Weiss30pct (1.1-dev)
< Weiss30pct (1.2-dev_20210110)
< Weiss30pct (1.5-dev)
< Weiss30pct (2.1-dev)
---
> Weiss_30pct (1.0-dev)
> Weiss_30pct (1.1-dev)
> Weiss_30pct (1.2-dev_20210110)
> Weiss_30pct (1.5-dev)
> Weiss_30pct (2.1-dev)
2069c2069
< Xiphos 0.6 (256th)
---
> Xiphos (0.6) [256th]
```